### PR TITLE
Fixes bug where block was never executed even if message was nil

### DIFF
--- a/lib/better_logging.rb
+++ b/lib/better_logging.rb
@@ -117,6 +117,12 @@ module PaulDowman
       def add_with_extra_info(severity, message = nil, progname = nil, &block)
         update_pid
         time = @@verbose ? "#{Time.now.iso8601(@@fraction_digits)} " : ""
+
+        if message.nil?
+          if block_given?
+            message = yield
+          end
+        end
         message = "#{time}#{ActiveSupport::BufferedLogger.severity_name(severity)} #{message}"
         
         # Make sure every line has the PID and hostname and custom string 


### PR DESCRIPTION
Paul:
Thanks for your plugin, it's pretty cool.

I've found a bug when using blocks instead of string messages, this commit fixes it.

Thanks!
